### PR TITLE
Update apt.pp

### DIFF
--- a/manifests/apt.pp
+++ b/manifests/apt.pp
@@ -23,7 +23,7 @@ class threatstack::apt {
     path => ['/bin', '/usr/bin']
   }
 
-  ensure_resource( 'package','curl', { 'ensure' => 'installed' } )
+  ensure_packages('curl')
 
   file { $apt_source_file:
     owner   => 'root',


### PR DESCRIPTION
If ensure_resource( 'package','curl', { 'ensure' => 'installed' } ) is used, it produces errors when used with some other puppet modules that also defile curl. 

Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Duplicate declaration: Package[curl] is already declared; cannot redeclare at /etc/puppet/environments/jbarthel/modules/threatstack/manifests/apt.pp:26 on node

That error is not produced with the fix.